### PR TITLE
Refine preferences styles for Ubuntu and macOS

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -26,7 +26,8 @@ body {
     height: 100%;
     min-height: 100%;
     overflow: hidden;
-    font-family: sans-serif, Verdana;
+    font-family: -apple-system, BlinkMacSystemFont, 'Ubuntu', 'Segoe UI', sans-serif;
+    font-size: 15px;
 }
 
 .window {
@@ -63,5 +64,78 @@ body {
     ::-webkit-scrollbar-thumb {
         background-color: #151515;
     }
+}
+
+/* Ubuntu 25 and macOS Sequoia inspired layout tweaks */
+.main {
+    width: 640px;
+    min-width: 640px;
+    max-width: 640px;
+    padding: 16px;
+    font-size: 15px;
+}
+
+.sidebar {
+    width: 220px;
+    min-width: 220px;
+    max-width: 220px;
+
+    .sidebar-section {
+        height: 48px;
+        min-height: 48px;
+        max-height: 48px;
+        width: 220px;
+        min-width: 220px;
+        max-width: 220px;
+        padding: 6px;
+
+        .section-icon {
+            width: 32px;
+            min-width: 32px;
+            max-width: 32px;
+            height: 32px;
+            min-height: 32px;
+            max-height: 32px;
+        }
+
+        .section-label {
+            font-size: 15px;
+        }
+    }
+}
+
+.group {
+    .group-label {
+        font-size: 22px;
+        margin-bottom: 12px;
+    }
+
+    .field {
+        margin-bottom: 24px;
+
+        .field-label {
+            font-size: 16px;
+        }
+
+        .help {
+            font-size: 13px;
+        }
+    }
+}
+
+.field-text input,
+.field-dropdown select,
+.field-secret input,
+.secret-modal input,
+.field-list .ep-list,
+.ep-list-modal-input,
+.field-accelerator input {
+    font-size: 15px;
+    padding: 10px;
+    border-radius: 6px;
+}
+
+.field-slider label {
+    font-size: 15px;
 }
 


### PR DESCRIPTION
## Summary
- tweak body font stack and size
- add main window and sidebar sizing rules
- refine group and field spacing
- unify input sizing

## Testing
- `npm install`
- `npm run build`
- `npm run lint`
- `npm test` *(fails: "argh, you called my bluff. We don't have any tests yet :(" )*

------
https://chatgpt.com/codex/tasks/task_e_6864f5a7017c832eb264bcde5135bdef