### PR TITLE
Fix build output paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test": "echo \"Error: argh, you called my bluff. We don't have any tests yet :(\" && exit 1",
     "example": "cd example && electron main.js",
     "prepare": "npm run build",
-    "build": "rimraf ./dist && tsc && rimraf ./build && webpack",
-    "build:dev": "rimraf ./dist && tsc && rimraf ./build && webpack --mode development",
+    "build": "rimraf ./dist && tsc && webpack",
+    "build:dev": "rimraf ./dist && tsc && webpack --mode development",
     "build:example": "npm run build && npm run example"
   },
   "author": "Tim Ambler <tkambler@gmail.com>",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,10 +9,10 @@ module.exports = {
 	watchOptions: {
 		ignored: /node_modules/,
 	},
-	output: {
-		path: path.resolve(__dirname, 'build'),
-		filename: 'app.js',
-	},
+        output: {
+                path: path.resolve(__dirname, 'dist', 'build'),
+                filename: 'app.js',
+        },
 	performance: {
 		maxAssetSize: 512000,
 		maxEntrypointSize: 512000,


### PR DESCRIPTION
## Summary
- output webpack build to `dist/build`
- simplify build scripts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867a1427f9c832e9e3ea8c0b6bbb678