### PR TITLE
Add atlas-css with accent-color support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "electron-preferences-modern",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-preferences-modern",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/atlas-css": "^3.67.0",
         "eventemitter2": "^6.4.9",
         "load-json-file": "^7.0.1",
         "lodash": "^4.17.21",
@@ -2000,6 +2001,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/atlas-css": {
+      "version": "3.67.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/atlas-css/-/atlas-css-3.67.0.tgz",
+      "integrity": "sha512-gcRUmhJtkTUCBLz0immwSsbUNQUP2j48d3u1/gOYOwCBb6MwFStaavOkVMl/+1Rpc6Jns5ac7UiBYGm+xrtIxA==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "xo": "^0.52.4"
   },
   "dependencies": {
+    "@microsoft/atlas-css": "^3.67.0",
     "eventemitter2": "^6.4.9",
     "load-json-file": "^7.0.1",
     "lodash": "^4.17.21",

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,3 +1,4 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 @use "../src/app/components/main/style" as *;
 @use "../src/app/components/main/components/group/style" as *;
 @use "../src/app/components/main/components/group/components/fields/accelerator/style" as *;
@@ -11,6 +12,11 @@
 @use "../src/app/components/main/components/group/components/fields/text/style" as *;
 @use "../src/app/components/main/components/group/components/fields/secret/style" as *;
 @use "../src/app/components/sidebar/style" as *;
+
+:root {
+    accent-color: var(--accent, #0078d4);
+    color-scheme: light dark;
+}
 
 html {
     margin: 0;


### PR DESCRIPTION
## Summary
- add `@microsoft/atlas-css` package
- import atlas-css in main stylesheet and set accent-color and color-scheme

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: "argh, you called my bluff. We don't have any tests yet :(")*

------
https://chatgpt.com/codex/tasks/task_e_686900bf5368832e8b6c7753487cae08