### PR TITLE
Integrate Atlas CSS into fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Run `npm run lint` and `npm run build` before committing.
+- Tests may fail; it's okay.
+- Prefer using SCSS with Atlas CSS components for styling.
+- Avoid changing JavaScript or TypeScript unless necessary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "electron-preferences-modern",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-preferences-modern",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/atlas-css": "^3.67.0",
         "eventemitter2": "^6.4.9",
         "load-json-file": "^7.0.1",
         "lodash": "^4.17.21",
@@ -2000,6 +2001,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/atlas-css": {
+      "version": "3.67.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/atlas-css/-/atlas-css-3.67.0.tgz",
+      "integrity": "sha512-gcRUmhJtkTUCBLz0immwSsbUNQUP2j48d3u1/gOYOwCBb6MwFStaavOkVMl/+1Rpc6Jns5ac7UiBYGm+xrtIxA==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "xo": "^0.52.4"
   },
   "dependencies": {
+    "@microsoft/atlas-css": "^3.67.0",
     "eventemitter2": "^6.4.9",
     "load-json-file": "^7.0.1",
     "lodash": "^4.17.21",

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,3 +1,4 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 @use "../src/app/components/main/style" as *;
 @use "../src/app/components/main/components/group/style" as *;
 @use "../src/app/components/main/components/group/components/fields/accelerator/style" as *;
@@ -11,6 +12,11 @@
 @use "../src/app/components/main/components/group/components/fields/text/style" as *;
 @use "../src/app/components/main/components/group/components/fields/secret/style" as *;
 @use "../src/app/components/sidebar/style" as *;
+
+:root {
+    accent-color: var(--accent, #0078d4);
+    color-scheme: light dark;
+}
 
 html {
     margin: 0;

--- a/src/app/components/main/components/group/components/fields/accelerator/style.scss
+++ b/src/app/components/main/components/group/components/fields/accelerator/style.scss
@@ -1,28 +1,7 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-accelerator {
-
   input {
+    @extend .input;
     width: 100%;
-    font-size: 14px;
-    padding: 8px;
-    background-color: rgb(243, 243, 243);
-    border-radius: 8px;
-    outline: none;
-    transition: border-color 0.1s ease-out;
-
-    &:focus {
-      border: 2px solid #b5c7d9;
-    }
-  }
-
-}
-
-@media (prefers-color-scheme: dark) {
-  .field-accelerator {
-
-    input {
-      color: #e4e4e4;
-      background-color: #3c3c3c;
-    }
   }
 }
-

--- a/src/app/components/main/components/group/components/fields/checkbox/style.scss
+++ b/src/app/components/main/components/group/components/fields/checkbox/style.scss
@@ -1,101 +1,14 @@
-/* ───────────────────────────────────────────────
- *  Цветовые токены
- * ───────────────────────────────────────────────*/
-:root {
-  --switch-off-border : #5d5d5d;    /* рамка OFF (light)  */
-  --switch-off-thumb  : #5d5d5d;    /* шар   OFF (light)  */
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --switch-off-border : #cecece;  /* рамка OFF (dark)   */
-    --switch-off-thumb  : #9c9c9c;  /* шар   OFF (dark)   */
-  }
-}
-
-/* ───────────────────────────────────────────────
- *  Переключатель
- * ───────────────────────────────────────────────*/
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-checkbox {
-
   .checkbox-option {
+    @extend .checkbox;
     display: flex;
     align-items: center;
     gap: 10px;
     margin: 8px 0;
 
-    input[type='checkbox'] {
-      /* трек -------------------------------------------------- */
-      appearance: none;
-      width: 40px; height: 18px;
-      border-radius: 20px;
-      border: 1px solid var(--switch-off-border);
-      background: transparent;
-      cursor: pointer;
-      position: relative;
-      padding: 0;
-
-      /* шар ---------------------------------------------------- */
-      &::before {
-        content: "";
-        position: absolute;
-        top: 50%; left: 9px;                 /* центр OFF */
-        transform: translate(-50%, -50%);
-        width: 12px; height: 12px;
-        border-radius: 50%;
-        background: var(--switch-off-thumb);
-      }
-
-      /* ── HOVER  (OFF) ─────────────────────────── */
-      &:hover:not(:checked) {
-        border-color: color-mix(in srgb, var(--switch-off-border) 85%, white);
-      }
-
-      /* шар растёт, НЕ смещается */
-      &:hover::before { width: 13px; height: 13px; }
-
-      /* ── ON ───────────────────────────────────── */
-      &:checked {
-        border-color: var(--accent);
-        background:   var(--accent);
-
-        &::before {
-          background: #fff;                         /* белый шар */
-          left: calc(100% - 10px);                 /* центр справа */
-        }
-
-        /* hover: Ø14, цвет трека чуть изменяем  */
-        &:hover::before { width: 14px; height: 14px; }
-      }
-
-      /* ── клавиатурный фокус ──────────────────── */
-      &:focus-visible {
-        outline: 2px solid var(--accent);
-        outline-offset: 2px;
-      }
+    .check-square {
+      @extend .checkbox-check;
     }
-  }
-}
-
-/* ───────────────────────────────────────────────
- *  Hover-фон: • light  → темнее на 20 %
- *             • dark   → светлее на 20 %
- *  Работает только в ON-состоянии (трека OFF прозрачный)
- * ───────────────────────────────────────────────*/
-.field-checkbox .checkbox-option
-input[type='checkbox']:checked:hover {
-  /* светлая тема: затемняем 20 % */
-  background: color-mix(in srgb, var(--accent) 90%, black);
-}
-@media (prefers-color-scheme: dark) {
-  .field-checkbox .checkbox-option
-  input[type='checkbox']:checked:hover {
-    /* тёмная тема: осветляем 20 % */
-    background: color-mix(in srgb, var(--accent) 90%, white);
-  }
-
-  /* чёрный шар ON (тёмная тема) */
-  .field-checkbox .checkbox-option
-  input[type='checkbox']:checked::before {
-    background: #000;
   }
 }

--- a/src/app/components/main/components/group/components/fields/color/style.scss
+++ b/src/app/components/main/components/group/components/fields/color/style.scss
@@ -1,6 +1,6 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-color {
-
-  .color{
+  .color {
     width: 36px;
     height: 14px;
     border-radius: 2px;
@@ -11,11 +11,9 @@
   }
 
   .color-swatch {
+    @extend .button;
     padding: 5px;
-    background: #fff;
-    border-radius: 1px;
     box-shadow: 0 0 0 1px rgba(0,0,0,.1);
-    display: inline-block;
     cursor: pointer;
   }
 
@@ -33,17 +31,8 @@
     bottom: 0;
     left: 0;
   }
-  
+
   .flexbox-fix {
     font-family: 'Open Sans', sans-serif;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .field-color {
-
-    .color-swatch {
-      background-color: #191919;
-    }
   }
 }

--- a/src/app/components/main/components/group/components/fields/dropdown/style.scss
+++ b/src/app/components/main/components/group/components/fields/dropdown/style.scss
@@ -1,29 +1,7 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-dropdown {
-
-    select {
-        width: 100%;
-        font-size: 14px;
-        border-radius: 8px;
-        border: 1px solid #e7e7e7;
-        background-color: #ffffff;
-        padding: 8px;
-        outline: none;
-        margin: 1px;
-
-        &:focus {
-            border: 2px solid #0084ff;
-            margin: 0;
-        }
-    }
-}
-
-@media (prefers-color-scheme: dark) {
-    .field-dropdown {
-
-        select {
-            color: #e4e4e4;
-            background-color: #191919;
-            border: 1px solid #131313;
-        }
-    }
+  select {
+    @extend .select;
+    width: 100%;
+  }
 }

--- a/src/app/components/main/components/group/components/fields/list/style.scss
+++ b/src/app/components/main/components/group/components/fields/list/style.scss
@@ -1,23 +1,8 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-list {
   .ep-list {
+    @extend .select;
     min-width: 25%;
-    font-size: 14px;
-    border-radius: 8px;
-    border: 1px solid #e7e7e7;
-    background-color: #ffffff;
-    padding: 0;
-    outline: none;
-    margin: 1px;
-    transition: border-color 0.3s ease-out;
-
-    &:active, &:focus {
-      border: 2px solid #0084ff;
-      margin: 0;
-    }
-
-    option {
-      padding: 2px 3px;
-    }
   }
 
   .ep-list-button-container {
@@ -25,37 +10,7 @@
   }
 
   .ep-list-button {
-    cursor: pointer;
-    border-top: 1px solid;
-    border-right: 1px solid;
-    border-bottom: 1px solid;
-    border-color: black;
-    background-color: #fff;
-    padding: 5px;
-    font-size: 14px;
-
-    &:first-child {
-      border: 1px solid;
-      border-top-left-radius: 8px;
-      border-bottom-left-radius: 8px;
-    }
-
-    &:last-child {
-      border: 1px solid;
-      border-left: none;
-      border-top-right-radius: 8px;
-      border-bottom-right-radius: 8px;
-    }
-  }
-
-  .ep-list-button:active {
-    border-color: #0084ff;
-    color: #0084ff;
-  }
-
-  .ep-list-button:disabled {
-    color: #bbb;
-    background-color: #666;
+    @extend .button;
   }
 
   .ep-list-button-text {
@@ -73,27 +28,15 @@
 }
 
 .ep-list-modal-input-container {
-    .ep-list-modal-input {
-        display: block;
-        width: 100%;
-        font-size: 14px;
-        border-radius: 8px;
-        border: 1px solid #e7e7e7;
-        background-color: #ffffff;
-        padding: 8px;
-        outline: none;
-        margin: 1px;
-        transition: border-color 0.3s ease-out;
-
-        &:focus {
-          border: 2px solid #0084ff;
-          margin: 0;
-        }
-    }
-    .ep-list-modal-input-label {
-        display: block;
-        font-weight: bold;
-    }
+  .ep-list-modal-input {
+    @extend .input;
+    display: block;
+    width: 100%;
+  }
+  .ep-list-modal-input-label {
+    display: block;
+    font-weight: bold;
+  }
 }
 
 .ep-list-modal-button-container {
@@ -105,19 +48,9 @@
 }
 
 .ep-list-modal-button {
+  @extend .button;
   flex: 0 1 auto;
-  border-radius: 8px;
-  border: 2px solid #999;
-  padding: 5px;
   margin: 3px;
-
-  &:disabled {
-    border-color: #ddd;
-  }
-
-  &:active {
-    border-color: #0084ff;
-  }
 }
 
 .ReactModalPortal {
@@ -148,51 +81,4 @@
 
 .ReactModal__Content {
   border-radius: 8px !important;
-}
-
-@media (prefers-color-scheme: dark) {
-  .field-list {
-    .ep-list {
-      color: white;
-      background-color: #191919;
-      border-color: #131313;
-    }
-
-    .ep-list-button {
-      background-color: #191919;
-      color: white;
-      border-color: #131313;
-
-      &:first-child, &:last-child {
-        border-color: #131313;
-      }
-    }
-  }
-
-  .ReactModal__Content {
-    background-color: #212121 !important;
-    border-color: #131313 !important;
-  }
-
-  .ep-list-modal-input-container {
-    .ep-list-modal-input {
-      color: #e4e4e4;
-      background-color: #191919;
-      border: 1px solid #131313;
-    }
-
-    .ep-list-modal-input-label {
-      color: white;
-    }
-  }
-
-  .ep-list-modal-button {
-    color: white;
-    background: #191919;
-    border: 2px solid grey;
-
-    &:disabled {
-      opacity: 0.7;
-    }
-  }
 }

--- a/src/app/components/main/components/group/components/fields/radio/style.scss
+++ b/src/app/components/main/components/group/components/fields/radio/style.scss
@@ -1,59 +1,15 @@
-/* общие токены для OFF-рамок (уже есть у switch)  */
-:root {
-  --switch-off-border : #5d5d5d;   /* светлая тема */
-  --radio-bg          : #ffffff;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --switch-off-border : #cecece; /* тёмная тема  */
-    --radio-bg          : #000000;
-  }
-}
-
-/* ───────────────────────────────────────────────
- *  Радио-кнопка
- * ───────────────────────────────────────────────*/
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-radio {
-
   .radio-option {
+    @extend .radio;
     display: block;
     position: relative;
     padding-left: 30px;
     margin-bottom: 12px;
-    cursor: pointer;
     user-select: none;
 
-    input[type='radio'] {
-      appearance: none;
-      position: absolute;
-      top: 0; left: 0;
-      width: 20px; height: 20px;
-      margin: 0;
-
-      /* ▼ OFF-рамка берёт тот же цвет, что чекбокс / свитч */
-      border: 1px solid var(--switch-off-border);
-      border-radius: 50%;
-      background: var(--radio-bg);
-      cursor: pointer;
-
-      /* внутренняя точка */
-      &::before {
-        content: "";
-        position: absolute;
-        width: 12px; height: 12px;
-        top: 50%; left: 50%;
-        transform: translate(-50%, -50%);
-        border-radius: 50%;
-        background: var(--accent);
-        display: none;
-      }
-
-      &:checked::before { display: block; }
-
-      &:focus-visible {
-        outline: 2px solid var(--accent);
-        outline-offset: 2px;
-      }
+    .check-circle {
+      @extend .radio-dot;
     }
   }
 }

--- a/src/app/components/main/components/group/components/fields/secret/style.scss
+++ b/src/app/components/main/components/group/components/fields/secret/style.scss
@@ -1,51 +1,24 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-secret {
-
   .input-button-container {
     width: 100%;
     display: flex;
 
     button {
+      @extend .button;
       flex: 0 0 auto;
     }
 
     input {
+      @extend .input;
       flex: 1 0 auto;
-    }
-  }
-
-  input {
-    font-size: 14px;
-    border-radius: 8px;
-    border: 1px solid #e7e7e7;
-    background-color: #ffffff;
-    padding: 8px;
-    outline: none;
-    margin: 1px;
-    transition: border-color 0.3s ease-out;
-
-    &:focus {
-      border: 2px solid #0084ff;
-      margin: 0;
     }
   }
 }
 
 .secret-modal {
-
   input {
-    font-size: 14px;
-    border-radius: 8px;
-    border: 1px solid #e7e7e7;
-    background-color: #ffffff;
-    padding: 8px;
-    outline: none;
-    margin: 1px;
-    transition: border-color 0.3s ease-out;
-
-    &:focus {
-      border: 2px solid #0084ff;
-      margin: 0;
-    }
+    @extend .input;
   }
 
   .buttons {
@@ -54,41 +27,10 @@
     justify-content: flex-end;
 
     button {
+      @extend .button;
       flex: 0 0 auto;
-      cursor: pointer;
-      border-top: 1px solid;
-      border-right: 1px solid;
-      border-bottom: 1px solid;
-      border-color: black;
-      background-color: #fff;
-      padding: 5px;
-      font-size: 14px;
-
-      &:first-child {
-        border: 1px solid;
-        border-top-left-radius: 8px;
-        border-bottom-left-radius: 8px;
-      }
-
-      &:last-child {
-        border: 1px solid;
-        border-left: none;
-        border-top-right-radius: 8px;
-        border-bottom-right-radius: 8px;
-      }
-
-      &:active {
-        border-color: #0084ff;
-        color: #0084ff;
-      }
-
-      &:disabled {
-        color: #bbb;
-        background-color: #666;
-      }
     }
   }
-
 }
 
 .ReactModalPortal {
@@ -119,43 +61,4 @@
 
 .ReactModal__Content {
   border-radius: 8px !important;
-}
-
-@media (prefers-color-scheme: dark) {
-  .field-secret {
-
-    input {
-      color: #e4e4e4;
-      background-color: #191919;
-      border: 1px solid #131313;
-    }
-  }
-
-  .secret-modal {
-
-    input {
-      color: #e4e4e4;
-      background-color: #191919;
-      border: 1px solid #131313;
-    }
-
-    .buttons {
-
-      button {
-        background-color: #191919;
-        color: white;
-        border-color: #131313;
-
-        &:first-child, &:last-child {
-          border-color: #131313;
-        }
-      }
-
-    }
-  }
-
-  .ReactModal__Content {
-    background-color: #212121 !important;
-    border-color: #131313 !important;
-  }
 }

--- a/src/app/components/main/components/group/components/fields/slider/style.scss
+++ b/src/app/components/main/components/group/components/fields/slider/style.scss
@@ -1,76 +1,13 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-slider {
-
   input {
+    @extend .input;
     width: 88%;
-    margin: 10px 0;
-    background-color: transparent;
-    -webkit-appearance: none;
-    outline: none;
-    opacity: 0.85;
-    -webkit-transition: .2s;
-    transition: opacity .2s;
-
-    &:focus {
-      outline: none;
-    }
-
-    &:hover {
-      opacity: 1;
-    }
-  }
-
-  input::-webkit-slider-runnable-track {
-    background: rgba(0, 0, 0, 0.1);
-    border: 0;
-    border-radius: 5px;
-    width: 100%;
-    height: 10px;
-    cursor: pointer;
-  }
-
-  input::-webkit-slider-thumb {
-    margin-top: -10px;
-    width: 15px;
-    height: 30px;
-    background: #006dd9;
-    border: 0;
-    border-radius: 10px;
-    cursor: pointer;
-    -webkit-appearance: none;
-  }
-
-  input:focus::-webkit-slider-runnable-track {
-    background: rgba(0, 0, 0, 0.15);
-  }
-
-  input:focus::-webkit-slider-thumb {
-    background: #46a6ff;
   }
 
   label {
     width: 8%;
     font-size: 14px;
     padding: 4px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .field-slider {
-
-    input {
-      opacity: 1;
-
-      &:hover {
-        opacity: 0.85;
-      }
-    }
-
-    input::-webkit-slider-runnable-track {
-      background: rgba(255, 255, 255, 0.05);
-    }
-
-    input:focus::-webkit-slider-runnable-track {
-      background: rgba(255, 255, 255, 0.1);
-    }
   }
 }

--- a/src/app/components/main/components/group/components/fields/text/style.scss
+++ b/src/app/components/main/components/group/components/fields/text/style.scss
@@ -1,31 +1,7 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 .field-text {
-
-    input {
-        width: 100%;
-        font-size: 14px;
-        border-radius: 8px;
-        border: 1px solid #e7e7e7;
-        background-color: #ffffff;
-        padding: 8px;
-        outline: none;
-        margin: 1px;
-        transition: border-color 0.3s ease-out;
-
-        &:focus {
-            border: 2px solid #0084ff;
-            margin: 0;
-        }
-    }
-
-}
-
-@media (prefers-color-scheme: dark) {
-    .field-text {
-
-        input {
-            color: #e4e4e4;
-            background-color: #191919;
-            border: 1px solid #131313;
-        }
-    }
+  input {
+    @extend .input;
+    width: 100%;
+  }
 }

--- a/src/app/components/main/components/group/style.scss
+++ b/src/app/components/main/components/group/style.scss
@@ -1,3 +1,4 @@
+@use "@microsoft/atlas-css/src/index.scss" as *;
 /* ------------------------------------------------------------------
  *  VARIABLES
  * -----------------------------------------------------------------*/
@@ -29,42 +30,8 @@
      *  BUTTON (Fluent–style)    «.bt»
      * -------------------------------------------------------------*/
     .bt {
-      display: inline-block;
-      padding: 6px 14px;
+      @extend .button;
       margin: 16px 0;
-      font-size: 14px;
-      //font-weight: 600;
-      line-height: 1;
-      color: #fff;
-      background: var(--accent);
-      border: 1px solid transparent;
-      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.8);
-      border-radius: 4px;            /* Win11 radii = 4-8 px */
-      text-transform: none;          /* Fluent не использует uppercase */
-      transition: background .15s, border-color .15s, box-shadow .15s;
-      cursor: pointer;
-      user-select: none;
-
-      &:hover,
-      &:focus-visible {
-        background: color-mix(in srgb, var(--accent) 90%, #ffffff);
-        outline: none;
-      }
-
-      &:active {
-        background: color-mix(in srgb, var(--accent) 80%, #ffffff);
-        box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
-        transform: translateY(1px);
-      }
-
-      &:disabled,
-      &[aria-disabled="true"] {
-        opacity: .45;
-        cursor: default;
-        box-shadow: none;
-        background: #d1d1d1;
-        color: #fff;
-      }
     }
   }
 }
@@ -79,19 +46,6 @@
 
       .help { color: #8c8c8c; }
 
-      .bt {
-        background: var(--accent);
-        color: #000;
-
-        &:hover,
-        &:focus-visible {
-
-        }
-
-        &:active {
-
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- switch field SCSS over to Atlas CSS
- keep buttons consistent by extending `.button`
- provide agent instructions for future contributors

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: "argh, you called my bluff. We don't have any tests yet :(")*

------
https://chatgpt.com/codex/tasks/task_e_686900bf5368832e8b6c7753487cae08