### PR TITLE
Add multi-instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ const { app } = require('electron');
 const path = require('path');
 
 const preferences = new ElectronPreferences({
-	config: {
+        // optional identifier to create multiple preference windows
+        id: 'main',
+        config: {
 		debounce: 150, // debounce preference save settings event; 0 to disable
 	},
 
@@ -196,10 +198,16 @@ const preferences = ipcRenderer.sendSync('getPreferences');
 ipcRenderer.send('showPreferences');
 // Or show a specific section:
 ipcRenderer.send('showPreferences', 'about');
+// When using multiple preference instances, append the id to the channel:
+ipcRenderer.send('showPreferences:plugins');
 
 // Listen to the `preferencesUpdated` event to be notified when preferences are changed.
 ipcRenderer.on('preferencesUpdated', (e, preferences) => {
-	console.log('Preferences were updated', preferences);
+        console.log('Preferences were updated', preferences);
+});
+// For instance specific events use the same id suffix:
+ipcRenderer.on('preferencesUpdated:plugins', (e, preferences) => {
+        console.log('Plugin preferences updated', preferences);
 });
 
 // Instruct the preferences service to update the preferences object from within the renderer.

--- a/example/index.html
+++ b/example/index.html
@@ -12,6 +12,8 @@
             <button class="bt">Reset to defaults</button>
             <button class="bt">Open 'Notes' section</button>
             <button class="bt">Decrypt user password</button>
+            <button class="bt">Open Preferences 2</button>
+            <button class="bt">Close Preferences 2</button>
         </div>
         <pre class="preferences"></pre>
         <script src="renderer.js"></script>

--- a/example/main.js
+++ b/example/main.js
@@ -7,7 +7,7 @@ const { nativeTheme } = electron;
 const { BrowserWindow } = electron;
 const path = require('path');
 const url = require('url');
-const preferences = require('./preferences');
+const { preferences, preferences2 } = require('./preferences');
 
 app.commandLine.appendSwitch('enable-smooth-scrolling');
 nativeTheme.themeSource = preferences.preferences?.theme?.theme ?? 'system';
@@ -28,6 +28,10 @@ preferences.on('click', (key) => {
             'We are logging something in the main process because of a button click in the preferences window!',
         );
     }
+});
+
+preferences2.on('save', (prefs) => {
+    console.log('Preferences2 were saved.', JSON.stringify(prefs, null, 4));
 });
 
 let mainWindow;

--- a/example/preferences.js
+++ b/example/preferences.js
@@ -471,4 +471,65 @@ const preferences = new ElectronPreferences({
     ],
 });
 
-module.exports = preferences;
+const preferences2 = new ElectronPreferences({
+    id: 'preferences2',
+    debug: true,
+    config: {
+        debounce: 10,
+        css: 'custom-style.css',
+        dataStore: path.resolve(__dirname, 'preferences2.json'),
+    },
+    defaults: {
+        basic: {
+            foo: 'bar',
+        },
+        misc: {
+            enableFeature: false,
+        },
+    },
+    browserWindowOverrides: {
+        title: 'My Electron Preferences 2',
+    },
+    sections: [
+        {
+            id: 'basic',
+            label: 'Basic',
+            icon: 'single-01',
+            form: {
+                groups: [
+                    {
+                        fields: [
+                            {
+                                label: 'Foo',
+                                key: 'foo',
+                                type: 'text',
+                                help: 'Example text field',
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            id: 'misc',
+            label: 'Misc',
+            icon: 'lock',
+            form: {
+                groups: [
+                    {
+                        fields: [
+                            {
+                                label: 'Enable feature',
+                                key: 'enableFeature',
+                                type: 'checkbox',
+                                options: [{ label: 'Yes', value: true }],
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    ],
+});
+
+module.exports = { preferences, preferences2 };

--- a/example/preload.js
+++ b/example/preload.js
@@ -4,23 +4,25 @@ const electron = require('electron');
 
 const { contextBridge } = electron;
 const { ipcRenderer } = electron;
+const ch = (name, id) => (id ? `${name}:${id}` : name);
 
 let onPreferencesChangedHandler = () => {};
 
 contextBridge.exposeInMainWorld('api', {
-    showPreferences: (section) => ipcRenderer.send('showPreferences', section),
-    closePreferences: () => ipcRenderer.send('closePreferences'),
-    getPreferences: () => ipcRenderer.sendSync('getPreferences'),
+    showPreferences: (section, id) =>
+        ipcRenderer.send(ch('showPreferences', id), section),
+    closePreferences: (id) => ipcRenderer.send(ch('closePreferences', id)),
+    getPreferences: (id) => ipcRenderer.sendSync(ch('getPreferences', id)),
     onPreferencesChanged(handler) {
         onPreferencesChangedHandler = handler;
     },
-    getDefaults: () => ipcRenderer.sendSync('getDefaults'),
-    resetToDefaults: () => ipcRenderer.send('resetToDefaults'),
-    decrypt: (encryptedSecret) =>
-        ipcRenderer.sendSync('decrypt', encryptedSecret),
+    getDefaults: (id) => ipcRenderer.sendSync(ch('getDefaults', id)),
+    resetToDefaults: (id) => ipcRenderer.send(ch('resetToDefaults', id)),
+    decrypt: (encryptedSecret, id) =>
+        ipcRenderer.sendSync(ch('decrypt', id), encryptedSecret),
 });
 
-ipcRenderer.on('preferencesUpdated', (e, preferences) => {
+ipcRenderer.on(ch('preferencesUpdated'), (e, preferences) => {
     onPreferencesChangedHandler(preferences);
 });
 

--- a/example/renderer.js
+++ b/example/renderer.js
@@ -6,6 +6,8 @@ const bt2 = document.querySelectorAll('.bt')[1];
 const bt3 = document.querySelectorAll('.bt')[2];
 const bt4 = document.querySelectorAll('.bt')[3];
 const bt5 = document.querySelectorAll('.bt')[4];
+const bt6 = document.querySelectorAll('.bt')[5];
+const bt7 = document.querySelectorAll('.bt')[6];
 const prefsElement = document.querySelectorAll('.preferences')[0];
 prefsElement.innerHTML = JSON.stringify(api.getPreferences(), null, 4);
 
@@ -35,6 +37,14 @@ bt5.addEventListener('click', () => {
 
     // eslint-disable-next-line no-alert
     alert(`Encrypted password: ${encrypted}\nDecrypted password: ${decrypted}`);
+});
+
+bt6.addEventListener('click', () => {
+    api.showPreferences(undefined, 'preferences2');
+});
+
+bt7.addEventListener('click', () => {
+    api.closePreferences('preferences2');
 });
 
 api.onPreferencesChanged((preferences) => {

--- a/index.ts
+++ b/index.ts
@@ -52,12 +52,23 @@ function diffPrefs(oldPrefs: any, newPrefs: any): string[] {
 }
 
 class ElectronPreferences extends EventEmitter2 {
+    /** map of instances by id */
+    static instances: Map<string, ElectronPreferences> = new Map();
+
     prefsWindow?: BrowserWindow | null;
     _preferences: any;
     options: any;
+    id?: string;
+
+    private ipcChannel(name: string) {
+        return this.id ? `${name}:${this.id}` : name;
+    }
 
     constructor(options: PreferencesOptions = {}) {
         super();
+
+        this.id = options.id;
+        ElectronPreferences.instances.set(this.id ?? 'default', this);
 
         _.defaultsDeep(options, {
             config: {
@@ -139,37 +150,37 @@ class ElectronPreferences extends EventEmitter2 {
 
         this.save();
 
-        ipcMain.on('showPreferences', (_, section) => {
+        ipcMain.on(this.ipcChannel('showPreferences'), (_, section) => {
             this.show(section);
         });
 
-        ipcMain.on('closePreferences', (_) => {
+        ipcMain.on(this.ipcChannel('closePreferences'), (_) => {
             this.close();
         });
 
-        ipcMain.on('getConfig', (event) => {
+        ipcMain.on(this.ipcChannel('getConfig'), (event) => {
             event.returnValue = this.options.config;
         });
 
-        ipcMain.on('getSections', (event) => {
+        ipcMain.on(this.ipcChannel('getSections'), (event) => {
             event.returnValue = jsonSerializer(this.options.sections);
         });
 
-        ipcMain.on('restoreDefaults', (_) => {
+        ipcMain.on(this.ipcChannel('restoreDefaults'), (_) => {
             this.preferences = this.defaults;
             this.save();
             this.broadcast();
         });
 
-        ipcMain.on('getDefaults', (event) => {
+        ipcMain.on(this.ipcChannel('getDefaults'), (event) => {
             event.returnValue = this.defaults;
         });
 
-        ipcMain.on('getPreferences', (event) => {
+        ipcMain.on(this.ipcChannel('getPreferences'), (event) => {
             event.returnValue = this.preferences;
         });
 
-        ipcMain.on('setPreferences', (event, value) => {
+        ipcMain.on(this.ipcChannel('setPreferences'), (event, value) => {
             const prevPrefs = _.cloneDeep(this.preferences);
             this.preferences = value;
             this.save();
@@ -183,20 +194,23 @@ class ElectronPreferences extends EventEmitter2 {
             event.returnValue = null;
         });
 
-        ipcMain.on('showOpenDialog', (event, dialogOptions) => {
-            event.returnValue = dialog.showOpenDialogSync(dialogOptions);
-        });
+        ipcMain.on(
+            this.ipcChannel('showOpenDialog'),
+            (event, dialogOptions) => {
+                event.returnValue = dialog.showOpenDialogSync(dialogOptions);
+            },
+        );
 
-        ipcMain.on('sendButtonClick', (_, message) => {
+        ipcMain.on(this.ipcChannel('sendButtonClick'), (_, message) => {
             // Main process
             this.emit('click', message);
         });
 
-        ipcMain.on('resetToDefaults', (_) => {
+        ipcMain.on(this.ipcChannel('resetToDefaults'), (_) => {
             this.resetToDefaults();
         });
 
-        ipcMain.on('encrypt', (event, secret) => {
+        ipcMain.on(this.ipcChannel('encrypt'), (event, secret) => {
             if (!safeStorage.isEncryptionAvailable()) {
                 console.warn(
                     "Cannot encrypt secret as electron's safeStorage isn't available",
@@ -210,7 +224,7 @@ class ElectronPreferences extends EventEmitter2 {
                 .toString('base64');
         });
 
-        ipcMain.on('decrypt', (event, encryptedSecret) => {
+        ipcMain.on(this.ipcChannel('decrypt'), (event, encryptedSecret) => {
             if (!safeStorage.isEncryptionAvailable()) {
                 console.warn(
                     "Cannot decrypt encrypted secret as electron's safeStorage isn't available",
@@ -281,7 +295,7 @@ class ElectronPreferences extends EventEmitter2 {
 
     broadcast() {
         for (const wc of webContents.getAllWebContents()) {
-            wc.send('preferencesUpdated', this.preferences);
+            wc.send(this.ipcChannel('preferencesUpdated'), this.preferences);
         }
     }
 

--- a/preload.ts
+++ b/preload.ts
@@ -3,6 +3,7 @@
 const electron = require('electron');
 const { contextBridge } = electron;
 const { ipcRenderer } = electron;
+const ch = (name, id) => (id ? `${name}:${id}` : name);
 
 // eslint-disable-next-line no-eval -- deserialize function for 'serialize-javascript' library
 const deserializeJson = (serializedJavascript) =>
@@ -10,21 +11,23 @@ const deserializeJson = (serializedJavascript) =>
 let onPreferencesUpdatedHandler;
 
 contextBridge.exposeInMainWorld('api', {
-    getSections: () => deserializeJson(ipcRenderer.sendSync('getSections')),
-    getPreferences: () => ipcRenderer.sendSync('getPreferences'),
-    getDefaults: () => ipcRenderer.sendSync('getDefaults'),
-    getConfig: () => ipcRenderer.sendSync('getConfig'),
-    setPreferences: (preferences) =>
-        ipcRenderer.send('setPreferences', preferences),
-    showOpenDialog: (dialogOptions) =>
-        ipcRenderer.sendSync('showOpenDialog', dialogOptions),
-    sendButtonClick: (channel) => ipcRenderer.send('sendButtonClick', channel),
-    encrypt: (secret) => ipcRenderer.sendSync('encrypt', secret),
+    getSections: (id) =>
+        deserializeJson(ipcRenderer.sendSync(ch('getSections', id))),
+    getPreferences: (id) => ipcRenderer.sendSync(ch('getPreferences', id)),
+    getDefaults: (id) => ipcRenderer.sendSync(ch('getDefaults', id)),
+    getConfig: (id) => ipcRenderer.sendSync(ch('getConfig', id)),
+    setPreferences: (preferences, id) =>
+        ipcRenderer.send(ch('setPreferences', id), preferences),
+    showOpenDialog: (dialogOptions, id) =>
+        ipcRenderer.sendSync(ch('showOpenDialog', id), dialogOptions),
+    sendButtonClick: (channel, id) =>
+        ipcRenderer.send(ch('sendButtonClick', id), channel),
+    encrypt: (secret, id) => ipcRenderer.sendSync(ch('encrypt', id), secret),
     onPreferencesUpdated(handler) {
         onPreferencesUpdatedHandler = handler;
     },
 });
-ipcRenderer.on('preferencesUpdated', (e, preferences) => {
+ipcRenderer.on(ch('preferencesUpdated'), (e, preferences) => {
     if (typeof onPreferencesUpdatedHandler === 'function') {
         onPreferencesUpdatedHandler(preferences);
     }

--- a/preload.ts
+++ b/preload.ts
@@ -3,7 +3,7 @@
 const electron = require('electron');
 const { contextBridge } = electron;
 const { ipcRenderer } = electron;
-const ch = (name, id) => (id ? `${name}:${id}` : name);
+const ch = (name:string, id?:string) => (id ? `${name}:${id}` : name);
 
 // eslint-disable-next-line no-eval -- deserialize function for 'serialize-javascript' library
 const deserializeJson = (serializedJavascript) =>

--- a/types/preferences.ts
+++ b/types/preferences.ts
@@ -59,6 +59,8 @@ export interface PreferencesSection extends PreferenceField {
 
 /** Constructor argument for `ElectronPreferences` */
 export interface PreferencesOptions {
+    /** instance id for multiple preference windows */
+    id?: string;
     /** Core storage configuration */
     config?: PreferencesConfig;
 


### PR DESCRIPTION
## Summary
- add optional `id` to `PreferencesOptions`
- map instances and add helper for id-aware IPC channel names
- adjust IPC calls to support multiple ids
- update preloads and README with new suffix usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f6eabd6bc832eaeca7ae72780783b