### PR TITLE
Add second preferences window example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -12,6 +12,8 @@
             <button class="bt">Reset to defaults</button>
             <button class="bt">Open 'Notes' section</button>
             <button class="bt">Decrypt user password</button>
+            <button class="bt">Open Preferences 2</button>
+            <button class="bt">Close Preferences 2</button>
         </div>
         <pre class="preferences"></pre>
         <script src="renderer.js"></script>

--- a/example/main.js
+++ b/example/main.js
@@ -7,7 +7,7 @@ const { nativeTheme } = electron;
 const { BrowserWindow } = electron;
 const path = require('path');
 const url = require('url');
-const preferences = require('./preferences');
+const { preferences, preferences2 } = require('./preferences');
 
 app.commandLine.appendSwitch('enable-smooth-scrolling');
 nativeTheme.themeSource = preferences.preferences?.theme?.theme ?? 'system';
@@ -28,6 +28,10 @@ preferences.on('click', (key) => {
             'We are logging something in the main process because of a button click in the preferences window!',
         );
     }
+});
+
+preferences2.on('save', (prefs) => {
+    console.log('Preferences2 were saved.', JSON.stringify(prefs, null, 4));
 });
 
 let mainWindow;

--- a/example/preferences.js
+++ b/example/preferences.js
@@ -471,4 +471,65 @@ const preferences = new ElectronPreferences({
     ],
 });
 
-module.exports = preferences;
+const preferences2 = new ElectronPreferences({
+    id: 'preferences2',
+    debug: true,
+    config: {
+        debounce: 10,
+        css: 'custom-style.css',
+        dataStore: path.resolve(__dirname, 'preferences2.json'),
+    },
+    defaults: {
+        basic: {
+            foo: 'bar',
+        },
+        misc: {
+            enableFeature: false,
+        },
+    },
+    browserWindowOverrides: {
+        title: 'My Electron Preferences 2',
+    },
+    sections: [
+        {
+            id: 'basic',
+            label: 'Basic',
+            icon: 'single-01',
+            form: {
+                groups: [
+                    {
+                        fields: [
+                            {
+                                label: 'Foo',
+                                key: 'foo',
+                                type: 'text',
+                                help: 'Example text field',
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            id: 'misc',
+            label: 'Misc',
+            icon: 'lock',
+            form: {
+                groups: [
+                    {
+                        fields: [
+                            {
+                                label: 'Enable feature',
+                                key: 'enableFeature',
+                                type: 'checkbox',
+                                options: [{ label: 'Yes', value: true }],
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    ],
+});
+
+module.exports = { preferences, preferences2 };

--- a/example/renderer.js
+++ b/example/renderer.js
@@ -6,6 +6,8 @@ const bt2 = document.querySelectorAll('.bt')[1];
 const bt3 = document.querySelectorAll('.bt')[2];
 const bt4 = document.querySelectorAll('.bt')[3];
 const bt5 = document.querySelectorAll('.bt')[4];
+const bt6 = document.querySelectorAll('.bt')[5];
+const bt7 = document.querySelectorAll('.bt')[6];
 const prefsElement = document.querySelectorAll('.preferences')[0];
 prefsElement.innerHTML = JSON.stringify(api.getPreferences(), null, 4);
 
@@ -35,6 +37,14 @@ bt5.addEventListener('click', () => {
 
     // eslint-disable-next-line no-alert
     alert(`Encrypted password: ${encrypted}\nDecrypted password: ${decrypted}`);
+});
+
+bt6.addEventListener('click', () => {
+    api.showPreferences(undefined, 'preferences2');
+});
+
+bt7.addEventListener('click', () => {
+    api.closePreferences('preferences2');
 });
 
 api.onPreferencesChanged((preferences) => {


### PR DESCRIPTION
## Summary
- expose a new `preferences2` with its own sections and datastore
- handle new preferences instance in `main.js`
- add buttons to show/close `preferences2` from renderer
- wire up buttons in example page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb67b44d8832e919d74635f53d745